### PR TITLE
Release docker image for arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ workflows:
           requires:
             - client-test
             - integration-tests
+      - publish:
+          filters:
+            branches:
+              only:
+                - master
+                - local_pr
 
 jobs:
   lint:
@@ -193,17 +199,31 @@ jobs:
           docker load -i scope.tar
           docker load -i cloud-agent.tar
       - run: |
-          test -z "${DOCKER_USER}" && exit 0
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-          for IMAGE in $IMAGES; do
-              test "${DOCKER_ORGANIZATION:-$DOCKER_USER}" = "weaveworks" || docker tag weaveworks/$IMAGE:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:latest
-              docker tag weaveworks/$IMAGE:latest ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:$(./tools/image-tag)
-              docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:latest
-              docker push ${DOCKER_ORGANIZATION:-$DOCKER_USER}/$IMAGE:$(./tools/image-tag)
-          done
-      - run: |
           test -z "${QUAY_USER}" && exit 0
           docker login -e '.' -u "$QUAY_USER" -p "$QUAY_PASSWORD" quay.io
           docker tag weaveworks/scope:$(./tools/image-tag) "quay.io/${QUAY_ORGANIZATION}/scope:$(./tools/image-tag)"
           docker push "quay.io/${QUAY_ORGANIZATION}/scope:$(./tools/image-tag)"
       - run: test -z "${UI_BUCKET_KEY_ID}" || (make BUILD_IN_CONTAINER=false ui-upload ui-pkg-upload)
+
+  publish:
+    machine:
+      image: ubuntu-1604:202007-01
+    working_directory: /home/circleci/scope
+    environment:
+      DEBUG: true
+    steps:
+      - checkout
+      - run: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.5.0/buildx-v0.5.0.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker run -it --rm --privileged tonistiigi/binfmt --install all
+            docker buildx create --use --name mybuilder
+      - run: docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+      - run: |
+            docker run --rm  --entrypoint=cat weaveworks/weaveexec@sha256:d19ca4e518ee3d52bfbd6c6b8fb90c258622462ff8386de39e15b0fa6edb02e5 /usr/bin/weaveutil > weaveutil_arm64
+            docker run --rm  --entrypoint=cat weaveworks/weaveexec@sha256:d19ca4e518ee3d52bfbd6c6b8fb90c258622462ff8386de39e15b0fa6edb02e5 /usr/bin/weaveutil > weaveutil
+      - run: |
+          docker buildx build --push --build-arg=revision=$(git rev-parse HEAD) --build-arg=SCOPE_SKIP_UI_ASSETS=true --platform linux/arm64,linux/amd64 -t ${DOCKER_ORGANIZATION:-$DOCKER_USER}/cloud-agent:$(./tools/image-tag) -t ${DOCKER_ORGANIZATION:-$DOCKER_USER}/cloud-agent:latest -f docker/Dockerfile.cloud-agent_multiarch .
+      - run: |
+          docker buildx build --push --build-arg=revision=$(git rev-parse HEAD) --build-arg=VERSION=$(git rev-parse --short HEAD) --platform linux/arm64,linux/amd64 -t ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:$(./tools/image-tag) -t ${DOCKER_ORGANIZATION:-$DOCKER_USER}/scope:latest -f docker/Dockerfile.scope_multiarch .

--- a/docker/Dockerfile.cloud-agent_multiarch
+++ b/docker/Dockerfile.cloud-agent_multiarch
@@ -1,0 +1,28 @@
+# stage 1
+FROM golangci/golangci-lint:latest as builder
+ARG SCOPE_SKIP_UI_ASSETS
+RUN apt-get update
+RUN apt-get install -y libpcap-dev time
+WORKDIR /root/go/src/github.com/weaveworks
+COPY / scope
+WORKDIR scope
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/root/go
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+RUN make BUILD_IN_CONTAINER=false GO_BUILD_INSTALL_DEPS= prog/scope
+
+# stage 2
+FROM alpine:3.11.3
+WORKDIR /home/weave
+RUN apk add --no-cache bash conntrack-tools iproute2 util-linux curl
+COPY --from=builder /root/go/src/github.com/weaveworks/scope/prog/scope /home/weave/
+
+ENTRYPOINT ["/home/weave/scope", "--mode=probe", "--no-app", "--probe.docker=true"]
+
+ARG revision
+LABEL works.weave.role="system" \
+      maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="cloud-agent" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"

--- a/docker/Dockerfile.scope_multiarch
+++ b/docker/Dockerfile.scope_multiarch
@@ -1,0 +1,35 @@
+# stage 1
+FROM golang:latest as builder
+ARG VERSION
+RUN apt-get update
+RUN apt-get install -y time
+COPY / /scope
+WORKDIR /scope
+RUN curl -L https://github.com/weaveworks/weave/releases/download/v2.1.3/weave -o weave
+RUN chmod u+x weave
+RUN if [ `uname -m` = "aarch64" ] ; then \
+       mv ./weaveutil_arm64 docker/weaveutil; \
+    else \
+       cp ./weaveutil docker/weaveutil; \
+    fi
+RUN time env GOGC=off CGO_ENABLED=1 go build -mod vendor -ldflags "-extldflags \"-static\" -X main.version="${VERSION}" -s -w" -tags 'netgo unsafe' -o runsvinit ./vendor/github.com/peterbourgon/runsvinit
+
+# stage 2
+FROM odidev/cloud-agent
+RUN apk add --no-cache runit
+COPY --from=builder /scope/weave /usr/bin/
+COPY --from=builder /scope/docker/weaveutil /usr/bin/
+COPY --from=builder /scope/runsvinit /home/weave/
+COPY docker/entrypoint.sh /home/weave/
+COPY docker/run-app /etc/service/app/run
+COPY docker/run-probe /etc/service/probe/run
+
+EXPOSE 4040
+ENTRYPOINT ["/home/weave/entrypoint.sh"]
+
+ARG revision
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="scope" \
+      org.opencontainers.image.source="https://github.com/weaveworks/scope" \
+      org.opencontainers.image.revision="${revision}" \
+      org.opencontainers.image.vendor="Weaveworks"


### PR DESCRIPTION
Hi

**Package Owner:** Prakriti Chauhan

**PR change Details:**
**$ Patch Details:** Following files has been modified and added:

- **docker/Dockerfile.cloud-agent_multiarch:** Added a new file for cloud-agent which uses multi-stage build that builds the scope binary in stage 1 and in stage 2 follows the same step as in Dockerfile.cloud-agent.

- **.circleci/config.yml:** Added a new job **publish** in order to use buildx to build and push image for both the platforms to dockerhub.

- **docker/Dockerfile.scope_multiarch:** Added a new file for cloud-agent which uses multi-stage that builds all the binaries in stage 1 and in stage 2 copies all the binaries same as Dockerfile.scope.

**$ Testing Detail :**
**Circle-ci Link -** https://app.circleci.com/pipelines/github/odidev/scope/9/workflows/769269ef-7292-41a5-a2bf-fd9c01e15e71/jobs/58 

**Dockerhub Link for scope -** https://hub.docker.com/repository/docker/odidev/scope 

**Dockerhub Link for cloud-agent -** https://hub.docker.com/repository/docker/odidev/cloud-agent 

**$ PR Description:** Here is my commit message :
Release docker image for arm64
Here is my PR description -
The following files have been modified and added:

- In **.circleci/config.yml** added a new job **publish** in order to use buildx to build and push images for both the platforms to dockerhub.

- Added **docker/Dockerfile.cloud-agent_multiarch** file for building cloud-agent image which uses multi-stage build that builds the scope binary in stage 1 and in stage 2 follows the same steps as written in Dockerfile.cloud-agent.

- Added **docker/Dockerfile.scope_multiarch** file for building scope image which uses multi-stage that builds all the binaries in stage 1 and in stage 2 copies all the binaries same as Dockerfile.scope.

**$Reviewer:** Pruthvi Teja Reddy

Thanks
Prakriti Chauhan